### PR TITLE
New env variable FORCE_RESET_PERMISSIONS to control resetting nginx webroot permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `SITE_PORT` | What Port does wordpress deliver assets to - Default `80` |
 | `SITE_TITLE` | The title of the Website - Default `Docker Wordpress`  |
 | `SITE_URL` | The Full site URL of the installation e.g. `wordpress.example.com` - Required for Install |
+| `FORCE_RESET_PERMISSIONS` | Force setting wordpress files ownership to web server user - Default `true` |
 
 
 ### Networking

--- a/install/etc/cont-init.d/30-wordpress
+++ b/install/etc/cont-init.d/30-wordpress
@@ -46,6 +46,7 @@ DB_PREFIX=${DB_PREFIX:-"wp_"}
 DB_PORT=${DB_PORT:-3306}
 SITE_TITLE=${SITE_TITLE:-"Wordpress Docker Site"}
 SITE_LOCALE=${SITE_LOCALE:-"en_US"}
+FORCE_RESET_PERMISSIONS=${FORCE_RESET_PERMISSIONS:-"true"}
 
 if [ -n "$SITE_PORT" ]; then
     SITE_PORT=":${SITE_PORT}"
@@ -53,8 +54,9 @@ fi
 
 ### Create Directory if doesn't exist
 mkdir -p ${NGINX_WEBROOT}
-chown -R ${NGINX_USER}:${NGINX_GROUP} ${NGINX_WEBROOT}
-
+if [ "${FORCE_RESET_PERMISSIONS}" == "true"  ]; then
+    chown -R ${NGINX_USER}:${NGINX_GROUP} ${NGINX_WEBROOT}
+fi
 ### Make sure that DB is accessible
 while true; do
     mysqlcmd="mysql -u$DB_USER -h$DB_HOST -p$DB_PASS -P$DB_PORT"
@@ -128,7 +130,11 @@ fi
 echo "alias wp-cli='cd ${NGINX_WEBROOT}; sudo -u ${NGINX_USER} wp-cli'" > /root/.bashrc
 
 ### Force Reset Permissions for Security
-silent chown -R ${NGINX_USER}:${NGINX_GROUP} ${NGINX_WEBROOT}
+
+if [ "${FORCE_RESET_PERMISSIONS}" == "true"  ]; then
+    silent chown -R ${NGINX_USER}:${NGINX_GROUP} ${NGINX_WEBROOT}
+fi
+
 echo "** [wordpress] Wordpress Initialization Complete, now starting webserver and PHP engine"
 
 touch /tmp/state/30-init-wordpress


### PR DESCRIPTION
Hi,

Copy paste from the other [PR docker-nginx](https://github.com/tiredofit/docker-nginx/pull/1) ownership adjustsments are also done here.

Some times it is not a good idea to always force webroot ownertship at container boot, for example when you have a very big webroot that is over NFS, and several containers will be doing that at the same time over the same files.

This PR adds a new env variable called FORCE_RESET_PERMISSIONS to control if ownership of files should be done.

Would it make sense to leave chown's  on the nginx image ? only run them when it is a new wordpress install, or better yet, make 09-nginx run last ?