### PR TITLE
fix sed statements in nginx configuration function

### DIFF
--- a/install/assets/functions/30-wordpress
+++ b/install/assets/functions/30-wordpress
@@ -8,11 +8,11 @@ bootstrap_filesystem() {
 configure_nginx() {
     ### Perform Nginx reverse proxy modifications
     if var_true "${ENABLE_HTTPS_REVERSE_PROXY}" ; then
-        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'on';|g" >> /etc/nginx/fastcgi_params
+        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'on';|g" /etc/nginx/fastcgi_params
         PROTOCOL="https://"
     else
         print_warn "Disabling Nginx Reverse Proxy HTTPS Termination Support"
-        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'off';|g" >> /etc/nginx/fastcgi_params
+        sed -i "s|fastcgi_param  HTTPS '.*';|fastcgi_param  HTTPS 'off';|g" /etc/nginx/fastcgi_params
         PROTOCOL="http://"
     fi
 }


### PR DESCRIPTION
Hi tiredofit, 

As I was debugging the [previous issue](https://github.com/tiredofit/docker-wordpress/pull/20), I saw an error in the logs related to a `sed` statement. I removed some extra `>>` redirects. 

Cheers