### PR TITLE
Add webroot path to find-replace

### DIFF
--- a/install/assets/functions/30-wordpress
+++ b/install/assets/functions/30-wordpress
@@ -74,7 +74,7 @@ update_url_configuration() {
         fi
         if [ "${SITE_URL_UPDATE_MODE,,}" = "all" ] || [ "${SITE_URL_UPDATE_MODE,,}" = "db" ]; then
             print_notice "Modifying wordpress to serve from ${wpoldurl} to ${PROTOCOL}${SITE_URL}${SITE_PORT} in database"
-            silent sudo -u "${NGINX_USER}" wp-cli search-replace "${wpoldurl}" "${PROTOCOL}${SITE_URL}${SITE_PORT}" --skip-columns=guid
+            silent sudo -u "${NGINX_USER}" wp-cli search-replace "${wpoldurl}" "${PROTOCOL}${SITE_URL}${SITE_PORT}" --skip-columns=guid --path="${NGINX_WEBROOT}"
         fi
     fi
 }


### PR DESCRIPTION
Hi tiredofit,

I found another issue with `SITE_URL_UPDATE_MODE`. I discovered that I also needed to add the path to the webroot in order for the DB update to occur via the `wp-cli find-replace`. After I added `--path="${NGINX_WEBROOT}"` the command ran and the DB updated. 

```
[tiredofit/wordpress:5.4.2 14:14:21 /] $ sudo -u "${NGINX_USER}" wp-cli search-replace "https://example.com" "https://dev.example.com" --skip-columns=guid
Error: This does not seem to be a WordPress installation.
Pass --path=`path/to/wordpress` or run `wp core download`.
[tiredofit/wordpress:5.4.2 14:14:25 /] $ which wordpress
[tiredofit/wordpress:5.4.2 14:15:05 /] $ which wp-cli
/usr/bin/wp-cli
[tiredofit/wordpress:5.4.2 14:15:15 /] $ 

```